### PR TITLE
Reduce server initialization delay from roots request timeout

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -175,7 +175,7 @@ function registerHandlers() {
 		try {
 			if (client.supportsCapability('roots')) {
 				try {
-					listRootsResult = await mcpServer.server.listRoots();
+					listRootsResult = await withTimeout(mcpServer.server.listRoots(), 2000, 'Roots list request timeout');
 				} catch (error) {
 					logger.debug(`Requested roots list but client returned error: ${JSON.stringify(error, null, 3)}`);
 				}
@@ -276,7 +276,7 @@ function registerHandlers() {
 				setWorkspacePath(process.env.WORKSPACE_FOLDER_PATHS);
 			} else if (client.supportsCapability('roots')) {
 				try {
-					await mcpServer.server.listRoots();
+					await withTimeout(mcpServer.server.listRoots(), 2000, 'Roots list request timeout');
 				} catch (error) {
 					logger.debug(`Requested roots list but client returned error: ${JSON.stringify(error, null, 3)}`);
 				}


### PR DESCRIPTION
## Summary
- prevent long hangs when requesting roots by adding a 2 second timeout

## Testing
- `npm test` *(fails: MCP error -32602: Tool apex-run-script not found; expected undefined to be truthy; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb74472388329adb1f390be1c08e4